### PR TITLE
 - Refactored to use extension model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ target/
 work/
 .idea/
 *.iml
-
+.project
+.settings
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -1,100 +1,105 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>1.554</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.jenkins-ci.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>1.554</version>
+	</parent>
 
-    <artifactId>semantic-versioning-plugin</artifactId>
-    <version>1.2-SNAPSHOT</version>
-    <packaging>hpi</packaging>
+	<artifactId>semantic-versioning-plugin</artifactId>
+	<version>1.2-SNAPSHOT</version>
+	<packaging>hpi</packaging>
 
-    <name>Semantic Versioning Plugin</name>
+	<name>Semantic Versioning Plugin</name>
 
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/semantic-versioning-plugin</url>
+	<url>http://wiki.jenkins-ci.org/display/JENKINS/semantic-versioning-plugin</url>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <phase>package</phase>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skipTests>true</skipTests>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<phase>package</phase>
 
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+		
+	</build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.0-rc1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.0-rc1</version>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.0-rc1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.0-rc1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.main</groupId>
+			<artifactId>maven-plugin</artifactId>
+			<version>1.509.2</version>
+		</dependency>
+	</dependencies>
 
-    <developers>
-        <developer>
-            <id>ciroque</id>
-            <name>Steve Wagner</name>
-            <email>scalawagz@outlook.com</email>
-        </developer>
-    </developers>
+	<developers>
+		<developer>
+			<id>ciroque</id>
+			<name>Steve Wagner</name>
+			<email>scalawagz@outlook.com</email>
+		</developer>
+	</developers>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
 
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <xmlOutputDirectory>target/site</xmlOutputDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+					<xmlOutputDirectory>target/site</xmlOutputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
 
-    <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/semantic-versioning-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/semantic-versioning-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/semantic-versioning-plugin</url>
-    </scm>
+	<scm>
+		<connection>scm:git:ssh://github.com/jenkinsci/semantic-versioning-plugin.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/semantic-versioning-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/semantic-versioning-plugin</url>
+	</scm>
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/SemanticVersioning/AbstractSematicParserDescription.java
+++ b/src/main/java/org/jenkinsci/plugins/SemanticVersioning/AbstractSematicParserDescription.java
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.SemanticVersioning;
+
+
+public abstract class AbstractSematicParserDescription extends hudson.model.Descriptor {
+
+	@Override
+	public abstract String getDisplayName();
+
+}

--- a/src/main/java/org/jenkinsci/plugins/SemanticVersioning/InvalidBuildFileFormatException.java
+++ b/src/main/java/org/jenkinsci/plugins/SemanticVersioning/InvalidBuildFileFormatException.java
@@ -25,7 +25,12 @@
 package org.jenkinsci.plugins.SemanticVersioning;
 
 public class InvalidBuildFileFormatException extends Exception {
-    public InvalidBuildFileFormatException(String message) {
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public InvalidBuildFileFormatException(String message) {
         super(message);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/SemanticVersioning/SemanticVersionBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/SemanticVersioning/SemanticVersionBuildWrapper.java
@@ -28,199 +28,249 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor.FormException;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jenkinsci.plugins.SemanticVersioning.parsing.*;
+import org.jenkinsci.plugins.SemanticVersioning.parsing.BuildDefinitionParser;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-
 public class SemanticVersionBuildWrapper extends BuildWrapper {
-    private static final String DEFAULT_ENVIRONMENT_VARIABLE_NAME = "SEMANTIC_APP_VERSION";
-    private static final String MISSING_BUILD_NUMBER = "-1";
-    private String environmentVariableName = DEFAULT_ENVIRONMENT_VARIABLE_NAME;
-    private static Logger logger = LogManager.getLogger(AppVersion.class);
+	private static final String DEFAULT_ENVIRONMENT_VARIABLE_NAME = "SEMANTIC_APP_VERSION";
+	private static final String MISSING_BUILD_NUMBER = "-1";
+	private String environmentVariableName = DEFAULT_ENVIRONMENT_VARIABLE_NAME;
+	private static Logger logger = LogManager.getLogger(AppVersion.class);
+	private BuildDefinitionParser parser;
 
-    @DataBoundConstructor
-    public SemanticVersionBuildWrapper(String environmentVariableName) {
-        logger.info("### SemanticVersionBuildWrapper");
-        this.environmentVariableName = environmentVariableName;
-    }
+	@DataBoundConstructor
+	public SemanticVersionBuildWrapper(String environmentVariableName,
+			String parser) {
+		logger.info("### SemanticVersionBuildWrapper");
+		this.environmentVariableName = environmentVariableName;
+		try {
+			this.parser = (BuildDefinitionParser) Jenkins.getInstance()
+					.getExtensionList(parser).iterator().next();
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+		}
+	}
 
-    /**
-     * Used from <tt>config.jelly</tt>.
-     * @return the value of the environment variable name to be used.
-     */
-    public String getEnvironmentVariableName() {
-        logger.info("### SemanticVersionBuildWrapper::getEnvironmentVariableName");
-        return this.environmentVariableName;
-    }
+	/**
+	 * Used from <tt>config.jelly</tt>.
+	 * 
+	 * @return the value of the environment variable name to be used.
+	 */
+	public String getEnvironmentVariableName() {
+		logger.info("### SemanticVersionBuildWrapper::getEnvironmentVariableName");
+		return this.environmentVariableName;
+	}
 
-    /**
-     * Used from <tt>config.jelly</tt>.
-     * @return the name of the file in which the semantic version will be stored.
-     */
-    public String getSemanticVersionFilename() {
-        return ".semanticVersion";
-    }
+	/**
+	 * Used from <tt>config.jelly</tt>.
+	 * 
+	 * @return the name of the file in which the semantic version will be
+	 *         stored.
+	 */
+	public String getSemanticVersionFilename() {
+		return ".semanticVersion";
+	}
+	
+	
+	/**
+	 * Used from <tt>config.jelly</tt>.
+	 * 
+	 * @return the canonical class name of the parser  which the semantic version use
+	 * to parse version number
+	 */
+	public String getParser() {
+		return this.parser.getClass().getCanonicalName();
+	}
 
-    @Override
-    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) {
-        logger.debug("### SemanticVersionBuildWrapper::setUp");
-        AppVersion appVersion = getAppVersion(build);
-        String buildNumber = getJenkinsBuildNumber(build);
+	@Override
+	public Environment setUp(AbstractBuild build, Launcher launcher,
+			BuildListener listener) {
+		logger.debug("### SemanticVersionBuildWrapper::setUp");
+		AppVersion appVersion = getAppVersion(build);
+		String buildNumber = getJenkinsBuildNumber(build);
 
-        appVersion.setBuild(Integer.parseInt(buildNumber));
+		appVersion.setBuild(Integer.parseInt(buildNumber));
 
-        logger.debug("### SemanticVersionBuildWrapper::setUp -> appVersion found to be: {" + getEnvironmentVariableName() + ": " + appVersion.getOriginal() + ", buildNumber: " + buildNumber + ", combined: " + appVersion.toString() + "}\n");
+		logger.debug("### SemanticVersionBuildWrapper::setUp -> appVersion found to be: {"
+				+ getEnvironmentVariableName()
+				+ ": "
+				+ appVersion.getOriginal()
+				+ ", buildNumber: "
+				+ buildNumber
+				+ ", combined: " + appVersion.toString() + "}\n");
 
-        final String reportedVersion = appVersion.toString();
+		final String reportedVersion = appVersion.toString();
 
-        writeVersionToFile(build, reportedVersion);
+		writeVersionToFile(build, reportedVersion);
 
-        return new Environment() {
-            @Override
-            public void buildEnvVars(Map<String, String> env) {
-                env.put(getEnvironmentVariableName(), reportedVersion);
-            }
-        };
-    }
+		return new Environment() {
+			@Override
+			public void buildEnvVars(Map<String, String> env) {
+				env.put(getEnvironmentVariableName(), reportedVersion);
+			}
+		};
+	}
 
-    private void writeVersionToFile(AbstractBuild build, String reportedVersion) {
-        String filename = getSemanticVersionFilename();
-        if(filename != null && filename.length() > 0) {
-            File file = new File(build.getArtifactsDir() + "/" + filename);
-            logger.info(build.getArtifactsDir() + "/" + filename);
-            try {
-                FileUtils.writeStringToFile(file, reportedVersion + "\n");
-            } catch (IOException e) {
-                logger.debug("Exception writing version to file: " + e);
-            }
-        }
-    }
+	private void writeVersionToFile(AbstractBuild build, String reportedVersion) {
+		String filename = getSemanticVersionFilename();
+		if (filename != null && filename.length() > 0) {
+			File file = new File(build.getArtifactsDir() + "/" + filename);
+			logger.info(build.getArtifactsDir() + "/" + filename);
+			try {
+				FileUtils.writeStringToFile(file, reportedVersion + "\n");
+			} catch (IOException e) {
+				logger.debug("Exception writing version to file: " + e);
+			}
+		}
+	}
 
-    private AppVersion getAppVersion(AbstractBuild build) {
-        logger.debug("### SemanticVersionBuildWrapper::getAppVersion");
-        AppVersion appVersion = AppVersion.EmptyVersion;
-        FilePath workspace = build.getWorkspace();
+	private AppVersion getAppVersion(AbstractBuild build) {
+		logger.debug("### SemanticVersionBuildWrapper::getAppVersion");
+		AppVersion appVersion = AppVersion.EmptyVersion;
+		if (this.parser != null) {
+			try {
+				logger.info("### SemanticVersionBuildWrapper::getAppVersion -> attempting to parse using "
+						+ parser.getClass().getSimpleName());
+				return parser.extractAppVersion(build);
 
-        Collection<BuildDefinitionParser> parsers = new ArrayList<BuildDefinitionParser>();
-        parsers.add(new PomParser(workspace + "/pom.xml"));
-        parsers.add(new BuildScalaParser(workspace + "/project/Build.scala"));
-        parsers.add(new SbtParser(workspace + "/build.sbt"));
+			} catch (IOException e) {
+				logger.error("EXCEPTION: " + e);
+			} catch (InvalidBuildFileFormatException e) {
+				logger.error("EXCEPTION: " + e);
+			}
+		}
 
-        for(BuildDefinitionParser parser : parsers) {
-            try {
-                logger.debug("### SemanticVersionBuildWrapper::getAppVersion -> attempting to parse using " + parser.getClass().getSimpleName());
-                appVersion = parser.extractAppVersion();
-                return appVersion;
-            } catch (IOException e) {
-                logger.error("EXCEPTION: " + e);
-            } catch (InvalidBuildFileFormatException e) {
-                logger.error("EXCEPTION: " + e);
-            }
-        }
+		return appVersion;
+	}
 
-        return appVersion;
-    }
+	private String getJenkinsBuildNumber(AbstractBuild build) {
+		logger.debug("### SemanticVersionBuildWrapper::getJenkinsBuildNumber");
+		EnvVars environmentVariables = null;
+		try {
+			environmentVariables = build.getEnvironment(TaskListener.NULL);
+		} catch (IOException e) {
+			logger.error("EXCEPTION: " + e);
+		} catch (InterruptedException e) {
+			logger.error("EXCEPTION: " + e);
+		}
+		return environmentVariables != null ? environmentVariables.get(
+				"BUILD_NUMBER", MISSING_BUILD_NUMBER) : MISSING_BUILD_NUMBER;
+	}
 
-    private String getJenkinsBuildNumber(AbstractBuild build) {
-        logger.debug("### SemanticVersionBuildWrapper::getJenkinsBuildNumber");
-        EnvVars environmentVariables = null;
-        try {
-            environmentVariables = build.getEnvironment(TaskListener.NULL);
-        } catch (IOException e) {
-            logger.error("EXCEPTION: " + e);
-        } catch (InterruptedException e) {
-            logger.error("EXCEPTION: " + e);
-        }
-        return environmentVariables != null ? environmentVariables.get("BUILD_NUMBER", MISSING_BUILD_NUMBER) : MISSING_BUILD_NUMBER;
-    }
+	@Extension
+	public static final DescriptorImpl descriptor = new DescriptorImpl();
 
-    @Extension
-    public static final DescriptorImpl descriptor = new DescriptorImpl();
+	@Override
+	public BuildWrapperDescriptor getDescriptor() {
+		return descriptor;
+	}
 
-    @Override
-    public BuildWrapperDescriptor getDescriptor() {
-        return descriptor;
-    }
+	/**
+	 * descriptor for {@link SemanticVersionBuildWrapper}. Used as a singleton.
+	 * The class is marked as public so that it can be accessed from views. See
+	 * <tt>src/main/resources/hudson/plugins/hello_world/SbtVersionExtracter/*.jelly</tt>
+	 * for the actual HTML fragment for the configuration screen.
+	 */
+	public static final class DescriptorImpl extends BuildWrapperDescriptor {
 
-    /**
-     * descriptor for {@link SemanticVersionBuildWrapper}. Used as a singleton.
-     * The class is marked as public so that it can be accessed from views.
-     * See <tt>src/main/resources/hudson/plugins/hello_world/SbtVersionExtracter/*.jelly</tt>
-     * for the actual HTML fragment for the configuration screen.
-     */
-    public static final class DescriptorImpl extends BuildWrapperDescriptor {
+		/**
+		 * In order to load the persisted global configuration, you have to call
+		 * load() in the constructor.
+		 */
+		public DescriptorImpl() {
+			super(SemanticVersionBuildWrapper.class);
+			logger.debug("### DescriptorImpl");
+			load();
+		}
 
-        /**
-         * In order to load the persisted global configuration, you have to
-         * call load() in the constructor.
-         */
-        public DescriptorImpl() {
-            super(SemanticVersionBuildWrapper.class);
-            logger.debug("### DescriptorImpl");
-            load();
-        }
+		/**
+		 * This human readable name is used in the configuration screen.
+		 * 
+		 * @return the display name for the plugin
+		 */
+		public String getDisplayName() {
+			logger.debug("### DescriptorImpl::getDisplayName");
+			return "Determine Semantic Version for project";
+		}
 
-        /**
-         * This human readable name is used in the configuration screen.
-         * @return the display name for the plugin
-         */
-        public String getDisplayName() {
-            logger.debug("### DescriptorImpl::getDisplayName");
-            return "Determine Semantic Version for project";
-        }
+		@Override
+		public boolean configure(StaplerRequest req, JSONObject json)
+				throws FormException {
+			logger.debug("### DescriptorImpl::configure");
+			
+			return super.configure(req, json);
+		}
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            logger.debug("### DescriptorImpl::configure");
-            return super.configure(req, json);
-        }
+		@Override
+		public boolean isApplicable(AbstractProject<?, ?> abstractProject) {
+			logger.debug("### DescriptorImpl::isApplicable");
+			return true;
+		}
 
-        @Override
-        public boolean isApplicable(AbstractProject<?, ?> abstractProject) {
-            logger.debug("### DescriptorImpl::isApplicable");
-            return true;
-        }
+		/**
+		 * Performs on-the-fly validation of the form field 'name'.
+		 * 
+		 * @param value
+		 *            This parameter receives the value that the user has typed.
+		 * @return Indicates the outcome of the validation. This is sent to the
+		 *         browser.
+		 */
+		public FormValidation doCheckEnvironmentVariableName(
+				@QueryParameter String value) {
+			logger.debug("### DescriptorImpl::doCheckEnvironmentVariableName");
+			if (value.isEmpty())
+				return FormValidation.error("Please set a name");
+			if (value.length() < 4)
+				return FormValidation.warning("Isn't the name too short?");
+			return FormValidation.ok();
+		}
 
-        /**
-         * Performs on-the-fly validation of the form field 'name'.
-         *
-         * @param value This parameter receives the value that the user has typed.
-         * @return Indicates the outcome of the validation. This is sent to the browser.
-         */
-        public FormValidation doCheckEnvironmentVariableName(@QueryParameter String value) {
-            logger.debug("### DescriptorImpl::doCheckEnvironmentVariableName");
-            if (value.length() == 0)
-                return FormValidation.error("Please set a name");
-            if (value.length() < 4)
-                return FormValidation.warning("Isn't the name too short?");
-            return FormValidation.ok();
-        }
+		/**
+		 * Generates LisBoxModel for available BuildDefinitionParsers
+		 * 
+		 * @return available BuildDefinitionParsers as ListBoxModel
+		 */
+		public ListBoxModel doFillParserItems() {
+			ListBoxModel parsersModel = new ListBoxModel();
+			for (BuildDefinitionParser parser : Jenkins.getInstance()
+					.getExtensionList(BuildDefinitionParser.class)) {
+				parsersModel.add(parser.getDescriptor().getDisplayName(), parser
+						.getClass().getCanonicalName());
+			}
 
-        /**
-         * Gets the default value for the environment variable name.
-         * @return the default value for the environment variable name.
-         */
-        public String getDefaultEnvironmentVariableName() {
-            logger.debug("### DescriptorImpl::getDefaultEnvironmentVariableName");
-            return SemanticVersionBuildWrapper.DEFAULT_ENVIRONMENT_VARIABLE_NAME;
-        }
-    }
+			return parsersModel;
+		}
+
+		/**
+		 * Gets the default value for the environment variable name.
+		 * 
+		 * @return the default value for the environment variable name.
+		 */
+		public String getDefaultEnvironmentVariableName() {
+			logger.debug("### DescriptorImpl::getDefaultEnvironmentVariableName");
+			return SemanticVersionBuildWrapper.DEFAULT_ENVIRONMENT_VARIABLE_NAME;
+		}
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/SemanticVersioning/parsing/AbstractBuildDefinitionParser.java
+++ b/src/main/java/org/jenkinsci/plugins/SemanticVersioning/parsing/AbstractBuildDefinitionParser.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.SemanticVersioning.parsing;
+
+import hudson.ExtensionList;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
+
+import org.apache.tools.ant.ExtensionPoint;
+
+/**
+ * BuilDefinitionParser abstraction layer for better backward compatibility
+ * @author timii
+ *
+ */
+
+public abstract class AbstractBuildDefinitionParser extends ExtensionPoint implements BuildDefinitionParser {
+
+	public static ExtensionList<BuildDefinitionParser> getParsers() {
+			return Jenkins.getInstance().getExtensionList(BuildDefinitionParser.class);
+	}
+	
+}

--- a/src/main/java/org/jenkinsci/plugins/SemanticVersioning/parsing/BuildDefinitionParser.java
+++ b/src/main/java/org/jenkinsci/plugins/SemanticVersioning/parsing/BuildDefinitionParser.java
@@ -24,11 +24,14 @@
 
 package org.jenkinsci.plugins.SemanticVersioning.parsing;
 
-import org.jenkinsci.plugins.SemanticVersioning.AppVersion;
-import org.jenkinsci.plugins.SemanticVersioning.InvalidBuildFileFormatException;
+import hudson.model.Describable;
+import hudson.model.AbstractBuild;
 
 import java.io.IOException;
 
-public interface BuildDefinitionParser {
-    AppVersion extractAppVersion() throws IOException, InvalidBuildFileFormatException;
+import org.jenkinsci.plugins.SemanticVersioning.AppVersion;
+import org.jenkinsci.plugins.SemanticVersioning.InvalidBuildFileFormatException;
+
+public interface BuildDefinitionParser extends Describable<BuildDefinitionParser> {
+    AppVersion extractAppVersion(AbstractBuild<?,?> build) throws IOException, InvalidBuildFileFormatException;
 }

--- a/src/main/resources/org/jenkinsci/plugins/SemanticVersioning/SemanticVersionBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/SemanticVersioning/SemanticVersionBuildWrapper/config.jelly
@@ -27,6 +27,9 @@
       Creates a text field that shows the value of the "name" property.
       When submitted, it will be passed to the corresponding constructor parameter.
     -->
+     <f:entry title="Versionumber parser" field="parser">
+        <f:select />
+    </f:entry>
     <f:entry
             title="Environment Variable Name"
             field="environmentVariableName">


### PR DESCRIPTION
Hi,

I refactored semantic-versioning-plugin to use extension point model so it can be extended with new semantic parsers in example ANT-parser.

I also refactored Pom Parser to resolve build file (pom.xml) from given root pom parameter, because at least in our build pom.xml locates at /<workspace_root>/workspace/<project_name>/pom.xml folder

and third and last modification is that now it is possible to select which parserer is used in that particular build job.
