### PR TITLE
[JENKINS-41968] Fixed the pom for release management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.5</version>
+		<version>2.30</version>
 	</parent>
 
 	<properties>
-		<jenkins.version>1.614</jenkins.version>
+		<jenkins.version>1.625.3</jenkins.version>
 	</properties>
 
 	<artifactId>semantic-versioning-plugin</artifactId>


### PR DESCRIPTION
@reviewbybees I cannot do a `clean install` locally when using parent pom version 2.30. Maven cannot resolve the dependency of Jenkins core 1.625.3:

```
Failed to execute goal on project semantic-versioning-plugin: Could not resolve dependencies for project org.jenkins-ci.plugins:semantic-versioning-plugin:hpi:1.13-SNAPSHOT: Could not find artifact org.jenkins-ci.main:jenkins-war:executable-war:1.625.3 in repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/)
```

But the `clean install` works with version 2.29 of plugin parent pom. Not sure if this is related to my environment.